### PR TITLE
Add oom language item

### DIFF
--- a/sel4-entry/build.rs
+++ b/sel4-entry/build.rs
@@ -22,7 +22,7 @@ fn main() {
                     "-target",
                     llvmtriple,
                     "-o",
-                    &*format!("{}/{}.o", out_dir, arch)
+                    &*format!("{}/{}.o", out_dir, arch),
                 ])
                 .status()
                 .unwrap()

--- a/sel4-entry/src/lib.rs
+++ b/sel4-entry/src/lib.rs
@@ -75,3 +75,15 @@ fn eh_personality() {
         core::intrinsics::abort();
     }
 }
+
+#[lang = "oom"]
+pub extern "C" fn oom() -> ! {
+    use core::fmt::Write;
+    let _ = write!(
+        sel4_sys::DebugOutHandle,
+        "----- aborting from out-of-memory -----\n"
+    );
+    unsafe {
+        core::intrinsics::abort();
+    }
+}


### PR DESCRIPTION
This commit adds a default `oom()` implementation that reports
out-of-memory using the seL4 debugging output handle.

Closes #1