### PR TITLE
moves fel4-specific configuration data to fel4.toml file

### DIFF
--- a/libsel4-sys/fel4.toml
+++ b/libsel4-sys/fel4.toml
@@ -1,0 +1,36 @@
+[fel4]
+artifact-path = "images"
+target-specs-path = "targets"
+default-target = "x86_64-sel4-helios"
+
+[sel4-cmake-options]
+# TODO - debug/release
+KernelDebugBuild = true
+KernelPrinting = true
+KernelOptimisation = "-02"
+# normal things
+KernelVerificationBuild = false
+KernelBenchmarks = "none"
+KernelDangerousCodeInjection = false
+KernelFastpath = true
+KernelMaxNumNodes = 1
+KernelRetypeFanOutLimit = 256
+KernelNumDomains = 1
+KernelMaxNumBootinfoUntypedCaps = 230
+KernelRootCNodeSizeBits = 19
+LibSel4FunctionAttributes = "public"
+KernelSupportPCID = false
+# libs/utils/etc
+SIMULATION = true
+
+[sel4-cmake-options.x86_64-sel4-helios]
+KernelArch = "x86"
+KernelX86Sel4Arch = "x86_64"
+KernelPlatPC99 = true
+
+[sel4-cmake-options.arm-sel4-helios]
+CROSS_COMPILER_PREFIX = "arm-linux-gnueabihf-"
+KernelArch = "arm"
+KernelArmSel4Arch = "aarch32"
+KernelARMPlatform = "sabre"
+KernelPlatformSabre = true


### PR DESCRIPTION
It should be noted that if / when this lands, all of the other examples in the workspace repository will be broken unless their config files are updated.