### PR TITLE
libsel4-sys: deterministic CMake configurations

### DIFF
--- a/libsel4-sys/build.rs
+++ b/libsel4-sys/build.rs
@@ -8,7 +8,7 @@ use cmake::Config;
 use package_config::process_cmake_cache;
 use std::env;
 use std::fs::File;
-use std::fs::{copy, create_dir};
+use std::fs::{copy, create_dir, remove_file};
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
 use toml::Value;
@@ -17,6 +17,17 @@ fn main() {
     let mut config = Config::new(".");
 
     configure_cmake_build(&mut config);
+
+    // delete any existing CMakeCache.txt to prevent seL4/CMake from
+    // unexpected reconfigurations
+    let prev_cache_path = PathBuf::from(getenv_unwrap("OUT_DIR"))
+        .join("build")
+        .join("CMakeCache.txt");
+
+    if prev_cache_path.exists() {
+        remove_file(prev_cache_path)
+            .expect("failed to delete previous CMakeCache.txt file");
+    }
 
     let cargo_output_path = config.build();
 


### PR DESCRIPTION
This commit enforces deterministic seL4+kernel CMake build configurations
by disallowing CMake re-configurations.

This is problematic when Cargo decides the libsel4-sys package needs to be
re-built; it would previously invoke CMake on an existing cache which as a
result would re-run seL4 CMake auto-configuration mechanisms against the
existing cache (taking precedence) rather than just the keys specified in the toml.