### PR TITLE
Add seL4_WordBits type for arm target

### DIFF
--- a/libsel4-sys/src/lib.rs
+++ b/libsel4-sys/src/lib.rs
@@ -73,6 +73,26 @@ pub unsafe extern "C" fn strcpy(
 }
 
 #[cfg(target = "arm-sel4-helios")]
+/// Number of bits in a `seL4_Word`.
+///
+/// # Remarks
+///
+/// Normally this is defined as the following macro:
+/// ```
+/// #define seL4_WordBits (sizeof(seL4_Word) * 8)
+/// ```
+///
+/// For our `arm-sel4-helios` target see file:
+/// `libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h`
+///
+/// However due to bindgen not being able to expand functional
+/// macros, the type gets ignored.
+///
+/// For the time being, we just provide the constant here.
+///
+/// See following issues for more information:
+/// - `rust-bindgen/issues/753`
+/// - `feL4-dependencies/issues/18`
 pub const seL4_WordBits: u32 = 32;
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
This enables our default root-task to build with the `arm-sel4-helios` target.

Since bindgen doesn't seem to expand function like macros, this gets us by for now.

Relates to #18