### PR TITLE
Use correct/portable syntax

### DIFF
--- a/libsel4-sys/src/lib.rs
+++ b/libsel4-sys/src/lib.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn strcpy(
     dest
 }
 
-#[cfg(target = "arm-sel4-helios")]
+#[cfg(all(target_arch = "arm", target_os = "sel4", target_env = "helios"))]
 /// Number of bits in a `seL4_Word`.
 ///
 /// # Remarks


### PR DESCRIPTION
Using target triple will not be supported, ie `{arch}-{vendor}-{sys}-{abi}` or similar with the `cfg target`.

This commit replaces the target triple with the `rustc` compatible tokens.

For curious readers, available `cfg`'s can be viewed with:
```
RUST_TARGET_PATH=/path/to/target_specs rustc --print cfg --target arm-sel4-helios
```

Which returns something like:
```
debug_assertions
target_arch="arm"
target_endian="little"
target_env="helios"
target_has_atomic="16"
target_has_atomic="32"
target_has_atomic="8"
target_has_atomic="ptr"
target_os="sel4"
target_pointer_width="32"
target_thread_local
target_vendor="unknown"
```
