### PR TITLE
Migrate target specifications

### DIFF
--- a/libsel4-sys/README.md
+++ b/libsel4-sys/README.md
@@ -39,12 +39,17 @@ Down-stream consumers can specify a toml file that contains the CMake configurat
 tables via the `HELIOS_MANIFEST_PATH` variable. If not set, the default package configuration
 will be used.
 
-## CMake Build Configuration
+## Build Configuration
+
+Example `fel4.toml`:
 
 ```
-[package.metadata.sel4-cmake-options]
-KernelDebugBuild = true
-KernelPrinting = true
+[fel4]
+artifact-path = "images"
+target-specs-path = "targets"
+default-target = "x86_64-sel4-fel4"
+
+[sel4-cmake-options]
 KernelOptimisation = "-02"
 KernelVerificationBuild = false
 KernelBenchmarks = "none"
@@ -57,17 +62,23 @@ KernelMaxNumBootinfoUntypedCaps = 230
 KernelRootCNodeSizeBits = 19
 LibSel4FunctionAttributes = "public"
 KernelSupportPCID = false
-SIMULATION = true
+BuildWithCommonSimulationSettings = true
 
-[package.metadata.sel4-cmake-options.x86_64-sel4-helios]
+[sel4-cmake-options.debug]
+KernelDebugBuild = true
+KernelPrinting = true
+
+[sel4-cmake-options.release]
+KernelDebugBuild = false
+KernelPrinting = false
+
+[sel4-cmake-options.x86_64-sel4-fel4]
 KernelArch = "x86"
 KernelX86Sel4Arch = "x86_64"
-KernelPlatPC99 = true
 
-[package.metadata.sel4-cmake-options.arm-sel4-helios]
+[sel4-cmake-options.arm-sel4-fel4]
 CROSS_COMPILER_PREFIX = "arm-linux-gnueabihf-"
 KernelArch = "arm"
 KernelArmSel4Arch = "aarch32"
 KernelARMPlatform = "sabre"
-KernelPlatformSabre = true
 ```

--- a/libsel4-sys/Xargo.toml
+++ b/libsel4-sys/Xargo.toml
@@ -1,4 +1,4 @@
-[target.x86_64-sel4-helios.dependencies]
+[target.x86_64-sel4-fel4.dependencies]
 alloc = {}
-[target.arm-sel4-helios.dependencies]
+[target.arm-sel4-fel4.dependencies]
 alloc = {}

--- a/libsel4-sys/build.rs
+++ b/libsel4-sys/build.rs
@@ -163,7 +163,7 @@ fn generate_bindings(
     let (kernel_arch, sel4_arch, width, plat) =
         get_bindgen_target_include_dirs(target, platform);
 
-    let target_args = if target == "arm-sel4-helios" {
+    let target_args = if target == "arm-sel4-fel4" {
         String::from("-mfloat-abi=hard")
     } else {
         String::from("")
@@ -205,14 +205,14 @@ fn get_bindgen_target_include_dirs(
     target: &String,
     platform: &String,
 ) -> (String, String, String, String) {
-    if target == "x86_64-sel4-helios" {
+    if target == "x86_64-sel4-fel4" {
         (
             "x86".to_string(),
             "x86_64".to_string(),
             "64".to_string(),
             platform.to_string(),
         )
-    } else if target == "arm-sel4-helios" {
+    } else if target == "arm-sel4-fel4" {
         // some platform names don't map one-to-one
         let plat_include = match platform.as_str() {
             "sabre" => "imx6",
@@ -357,7 +357,7 @@ fn add_cmake_target_options(
             continue;
         }
 
-        if target == "arm-sel4-helios" && key == "KernelARMPlatform" {
+        if target == "arm-sel4-fel4" && key == "KernelARMPlatform" {
             platform = value
                 .as_str()
                 .expect("failed to extract KernelARMPlatform value")

--- a/libsel4-sys/src/lib.rs
+++ b/libsel4-sys/src/lib.rs
@@ -72,7 +72,7 @@ pub unsafe extern "C" fn strcpy(
     dest
 }
 
-#[cfg(all(target_arch = "arm", target_os = "sel4", target_env = "helios"))]
+#[cfg(all(target_arch = "arm", target_os = "sel4", target_env = "fel4"))]
 /// Number of bits in a `seL4_Word`.
 ///
 /// # Remarks
@@ -82,7 +82,7 @@ pub unsafe extern "C" fn strcpy(
 /// #define seL4_WordBits (sizeof(seL4_Word) * 8)
 /// ```
 ///
-/// For our `arm-sel4-helios` target see file:
+/// For our `arm-sel4-fel4` target see file:
 /// `libsel4/sel4_arch_include/aarch32/sel4/sel4_arch/constants.h`
 ///
 /// However due to bindgen not being able to expand functional

--- a/libsel4-sys/test_configs/fel4.toml
+++ b/libsel4-sys/test_configs/fel4.toml
@@ -1,7 +1,7 @@
 [fel4]
 artifact-path = "images"
 target-specs-path = "targets"
-default-target = "x86_64-sel4-helios"
+default-target = "x86_64-sel4-fel4"
 
 [sel4-cmake-options]
 KernelOptimisation = "-02"
@@ -26,11 +26,11 @@ KernelPrinting = true
 KernelDebugBuild = false
 KernelPrinting = false
 
-[sel4-cmake-options.x86_64-sel4-helios]
+[sel4-cmake-options.x86_64-sel4-fel4]
 KernelArch = "x86"
 KernelX86Sel4Arch = "x86_64"
 
-[sel4-cmake-options.arm-sel4-helios]
+[sel4-cmake-options.arm-sel4-fel4]
 CROSS_COMPILER_PREFIX = "arm-linux-gnueabihf-"
 KernelArch = "arm"
 KernelArmSel4Arch = "aarch32"

--- a/sel4-entry/Xargo.toml
+++ b/sel4-entry/Xargo.toml
@@ -1,4 +1,4 @@
-[target.x86_64-sel4-helios.dependencies]
+[target.x86_64-sel4-fel4.dependencies]
 alloc = {}
-[target.arm-sel4-helios.dependencies]
+[target.arm-sel4-fel4.dependencies]
 alloc = {}

--- a/sel4-entry/build.rs
+++ b/sel4-entry/build.rs
@@ -43,11 +43,11 @@ fn main() {
     println!("cargo:rustc-link-search=native={}", out_dir);
 
     let target = env::var("TARGET").unwrap();
-    if target == "i686-sel4-helios" {
+    if target == "i686-sel4-fel4" {
         println!("cargo:rustc-link-lib=static=x86");
-    } else if target == "x86_64-sel4-helios" {
+    } else if target == "x86_64-sel4-fel4" {
         println!("cargo:rustc-link-lib=static=x86_64");
-    } else if target == "arm-sel4-helios" {
+    } else if target == "arm-sel4-fel4" {
         println!("cargo:rustc-link-lib=static=arm");
     }
 }


### PR DESCRIPTION
Migrating from `<arch>-sel4-helios` to `<arch>-sel4-fel4`.

See the target specifications repository:
https://github.com/PolySync/feL4-targets