### PR TITLE
Enable ability to multi-stage build ARM

### DIFF
--- a/libsel4-sys/build.rs
+++ b/libsel4-sys/build.rs
@@ -120,7 +120,7 @@ fn print_cargo_rerun_if_flags() {
     println!("cargo:rerun-if-env-changed=OUT_DIR");
     println!("cargo:rerun-if-env-changed=FEL4_MANIFEST_PATH");
     println!("cargo:rerun-if-env-changed=FEL4_ARTIFACT_PATH");
-    println!("cargo:rerun-if-env-changed=FEL4_ROOT_TASK_IMAGE");
+    println!("cargo:rerun-if-env-changed=FEL4_ROOT_TASK_IMAGE_PATH");
     println!("cargo:rerun-if-changed=package");
     println!("cargo:rerun-if-changed=package/CMakeLists.txt");
 }

--- a/libsel4-sys/package/CMakeLists.txt
+++ b/libsel4-sys/package/CMakeLists.txt
@@ -84,7 +84,7 @@ elseif("${KernelArch}" STREQUAL "arm")
 
     # WARNING - this will likely change as we migrate to a Rust project
     #
-    # This is brittle, and won't complain if the `FEL4_ROOT_TASK_IMAGE` variable is not set.
+    # This is brittle, and won't complain if the `FEL4_ROOT_TASK_IMAGE_PATH` variable is not set.
     #
     # This is intentional and a step in the right direction until we have a
     # fully formed Rust bootstrapping tool.
@@ -92,7 +92,7 @@ elseif("${KernelArch}" STREQUAL "arm")
     # build kernel binary and libsel4.a without having a root-task image.
     # Then on further invocations (assuming environment variable is set) you can
     # have the elfloader-tool pick up the root-task image and link everthing together.
-    set_property(TARGET rootserver_image PROPERTY ROOTSERVER_IMAGE "$ENV{FEL4_ROOT_TASK_IMAGE}")
+    set_property(TARGET rootserver_image PROPERTY ROOTSERVER_IMAGE "$ENV{FEL4_ROOT_TASK_IMAGE_PATH}")
 endif()
 
 # mock what we want to export for the build system, uses relative paths for now


### PR DESCRIPTION
This commit enables the underlying CMake infrastructure to handle
multi-stage ARM builds.

We take advantage of this in order to circumvent the seL4 build chain where
it requires a built root-task image in order to build/link the elfloader-tool
with the kernel and root-task image.

On the first build, the elfloader-tool is not aware of the root-task image because it
doesn't exist yet. On further invocations, you can set the environment variable
`FEL4_ROOT_TASK_IMAGE_PATH` to have it be picked up by the elfloader-tool and become
linked into the final bootable image.

This is not a production friendly feature, and will become solidified as
we determine how to best handle our build staging.