### PR TITLE
Enable verification builds, remove cmake restriction

### DIFF
--- a/libsel4-sys/package/CMakeLists.txt
+++ b/libsel4-sys/package/CMakeLists.txt
@@ -22,9 +22,6 @@ if(BuildWithCommonSimulationSettings)
     GenerateSimulateScript()
 endif(BuildWithCommonSimulationSettings)
 
-# TODO - remove override
-ApplyCommonReleaseVerificationSettings(OFF OFF)
-
 # disable GC sections as it causes binaries to be stripped sometimes
 set(UserLinkerGCSections OFF CACHE BOOL "" FORCE)
 


### PR DESCRIPTION
Now that we have all options declared in toml, we do not need to rely too much on
any of the helper functions in the Cmake files.

This change removes the call to Cmake helper function `ApplyCommonReleaseVerificationSettings()`.

The Cmake crate will handle the `CMAKE_BUILD_TYPE` depending on the build profile.

Verification options can be set in the fel4.toml file.

Closes #25